### PR TITLE
Reset state to before owner abandoned it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,70 @@
-# Deprecated
+# heroku-buildpack-apt
 
-This project is deprecated and is no longer being maintained.
+Add support for apt-based dependencies during both compile and runtime.
 
-Please check out my current project [Convox](https://convox.com) for all of your deployment needs!
+## Usage
+
+This buildpack works best with [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi) so that it can be used with your app's existing buildpacks.
+
+Include a list of apt package names to be installed in a file named `Aptfile`
+
+## Example
+
+#### .buildpacks
+
+    https://github.com/ddollar/heroku-buildpack-apt
+    https://github.com/heroku/heroku-buildpack-ruby
+
+#### Aptfile
+
+    libpq-dev
+    http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.1/wkhtmltox-0.12.1_linux-precise-amd64.deb
+
+#### Gemfile
+
+    source "https://rubygems.org"
+    gem "pg"
+    
+### Compile with [Anvil](https://github.com/ddollar/anvil-cli)
+
+    $ heroku plugins:install https://github.com/ddollar/heroku-build
+    
+    $ heroku create apt-pg-test
+    
+    $ heroku build . -b ddollar/multi -r 
+	Checking for app files to sync... done, 2 files needed
+	Uploading: 100.0%
+	Launching build process... done
+	Preparing app for compilation... done
+	Fetching buildpack... done
+	Detecting buildpack... done, Multipack
+	Fetching cache... done
+	Compiling app...
+	=====> Downloading Buildpack: https://github.com/ddollar/heroku-buildpack-apt
+	=====> Detected Framework: Apt
+	  Updating apt caches
+	  ...
+	  Installing libpq-dev_8.4.17-0ubuntu10.04_amd64.deb
+	  Installing libpq5_8.4.17-0ubuntu10.04_amd64.deb
+	  Writing profile script
+	=====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-ruby
+	=====> Detected Framework: Ruby
+	  Installing dependencies using Bundler version 1.3.2
+	  ...
+	Putting cache... done
+	Creating slug... done
+	Uploading slug... done
+	Success, slug is https://api.anvilworks.org/slugs/00000000-0000-0000-0000-0000000000.tgz
+	
+### Check out the PG library version
+
+    $ heroku run bash -a apt-pg-test
+    ~ $ irb
+	irb(main):001:0> require "pg"
+	=> true
+	irb(main):002:0> PG::version_string
+	=> "PG 0.15.1"
+	
+## License
+
+MIT

--- a/bin/compile
+++ b/bin/compile
@@ -10,15 +10,6 @@ set -e
 YELLOW='\033[1;33m'
 RESET='\033[0m'
 
-echo -e "${YELLOW}WARNING: This buildpack is no longer maintained."
-echo -e
-echo -e "Please choose a different buildpack or go to https://github.com/ddollar/heroku-buildpack-apt"
-echo "and fork it to your own account."
-echo -e
-echo -e "This buildpack will cease to function at the stroke of midnight on January 1, 2017.${RESET}"
-
-[ $(date +%Y%m%d%H%M%S) -gt "20170101000000" ] && exit 1
-
 # parse and derive params
 BUILD_DIR=$1
 CACHE_DIR=$2


### PR DESCRIPTION
Owner of the project has abandoned all of his heroku buildpacks, putting in self destructs and replacing the README with an abandon notice. Rolled back to before.
